### PR TITLE
add ДЗ №3

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -15,6 +15,13 @@ spec:
   containers:
   - name: web
     image: bart08rus/my-app-nonroot:latest
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 80
+    livenessProbe:
+      tcpSocket:
+        port: 8000
     volumeMounts:
       - name: app
         mountPath: /app

--- a/kubernetes-networks/.canary/canary-deploy.yaml
+++ b/kubernetes-networks/.canary/canary-deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canary
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: canary
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        app: canary
+    spec:
+      initContainers:
+      - name: init-container
+        image: busybox:stable
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      containers:
+      - name: web
+        image: bart08rus/my-app-nonroot:latest
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/.canary/canary-ingress.yaml
+++ b/kubernetes-networks/.canary/canary-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: canary
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "canary"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /web
+            pathType: Prefix
+            backend:
+              service:
+                name: canary-svc-cip
+                port:
+                  number: 8000

--- a/kubernetes-networks/.canary/canary-svc-cip.yaml
+++ b/kubernetes-networks/.canary/canary-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary-svc-cip
+spec:
+  selector:
+    app: canary
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/.coredns/dns-service.yaml
+++ b/kubernetes-networks/.coredns/dns-service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns-service-lb-172.17.255.10"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dnstcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns-service-lb-172.17.255.10"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+    - name: dnsudp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/kubernetes-networks/.dashboard/crb.yaml
+++ b/kubernetes-networks/.dashboard/crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/kubernetes-networks/.dashboard/ingress.yaml
+++ b/kubernetes-networks/.dashboard/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /dashboard/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: kubernetes-dashboard
+                port:
+                  number: 443

--- a/kubernetes-networks/.dashboard/sa.yaml
+++ b/kubernetes-networks/.dashboard/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/kubernetes-networks/.dashboard/secret.yaml
+++ b/kubernetes-networks/.dashboard/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/service-account.name: "admin-user"   
+type: kubernetes.io/service-account-token

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: cheap
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.17.255.1-172.17.255.255

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      initContainers:
+      - name: init-container
+        image: busybox:stable
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      containers:
+      - name: web
+        image: bart08rus/my-app-nonroot:latest
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /web
+            pathType: Prefix
+            backend:
+              service:
+                name: web-svc
+                port:
+                  number: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [+] Основное ДЗ
 - [+] Задание со *

## В процессе сделано:
 - Добавлены проверки readinessProbe и livenessProbe в Pod [intro/web-pod.yml](kubernetes-intro/web-pod.yaml)
 - Создан Deployment [web-deploy.yaml](kubernetes-networks/web-deploy.yaml)
 - Созданы сервисы типа [ClusterIP](kubernetes-networks/web-svc-cip.yaml), [LoadBalancer](kubernetes-networks/web-svc-lb.yaml) и [Headless](kubernetes-networks/web-svc-headless.yaml)
 - Включил IPVS
    ```
    ...
    ipvs:
        strictARP: true
    ...
    mode: "ipvs"
    ...
    ```
 - Установил MetalLB
 - Настроил балансировщик с помощью `ConfigMap`, манифест: [metallb-config.yaml](kubernetes-networks/metallb-config.yaml)
 - Сделаны манифесты сервисов типа `LoadBalancer`, которые откроют доступ к CoreDNS снаружи кластера (позволит получать записи через внешний IP).
 - Установлен `Ingress`
 - Создан файл [nginx-lb.yaml](kubernetes-networks/nginx-lb.yaml) c конфигурацией `LoadBalancer` - сервиса.
 - Создан Headless-сервис [web-svc-headless.yaml](kubernetes-networks/web-svc-headless.yaml) для нашего веб-приложения.
 - Настроен наш ingress-прокси, манифест с ресурсом `Ingress` [web-ingress.yaml](kubernetes-networks/web-ingress.yaml)
 - Установлен `kubernetes-dashboard`. Манифесты в подкаталоге [./dashboard](kubernetes-networks/.dashboard)
 - Реализовано канареечное развертывание с помощью `ingress-nginx`. Манифесты в подкаталоге [./canary](kubernetes-networks/.canary)

## Как запустить проект:
 - Установка `MetalLB` и настройка балансировщика с помощью `ConfigMap` из каталога `kubernetes-networks`
    ```sh
    kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
    kubectl apply -f metallb-config.yaml
    ```
 - Установка `Ingress` и настройка ingress-прокси из каталога `kubernetes-networks`
    ```
    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml
    kubectl apply -f nginx-lb.yaml
    ```
 - Запуск веб-приложения из каталога `kubernetes-networks`
    ```
    kubectl apply -f web-deploy.yaml -f web-svc-cip.yaml -f web-svc-headless.yaml -f web-svc-lb.yaml
    ```
 - Запуск сервиса для открытия доступа к CoreDNS снаружи кластера из каталога `/kubernetes-networks/.coredns`
    ```
    kubectl apply -f .
    ```
 - Установка `kubernetes-dashboard` и открытие доступа через наш Ingress-прокси производится из каталога `./kubernetes-networks/.dashboard`
    ```
    kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
    kubectl apply -f .
    ```
 - Запуск веб-приложения реализовного через канареечное развертывание из каталога `/kubernetes-networks/.canary`
    ```
    kubectl apply -f .
    ```

## Как проверить работоспособность:
 - Проверка работоспособности web-приложения. Перейти по ссылке http://{ingress-nginx-service-lb-ip}/web
 - Проверка работоспособности kubernetes-dashboard. Перейти по ссылке http://{ingress-nginx-service-lb-ip}/dashboard
 - Проверка канареечного развертывания
    Запрос без HTTP-заголовка:
    ```
    curl http://{ingress-nginx-service-lb-ip}/web | grep HOSTNAME
    ```
    Ответ:
    ```
    export HOSTNAME='web-769478cfc8-l6p7g'
    ```
    Запрос с HTTP-заголовком "canary: true":
    ```
    curl -H "canary: true" http://{ingress-nginx-service-lb-ip}/web | grep HOSTNAME
    ```
    Ответ:
    ```
    export HOSTNAME='canary-b6f6ccd4d-xzxp4'
    ```

## PR checklist:
 - [+] Выставлен label с темой домашнего задания